### PR TITLE
fix: use docker:latest for snyk/snyk:docker

### DIFF
--- a/alpine
+++ b/alpine
@@ -6,6 +6,6 @@ composer php
 docker:18.09 docker-18.09
 docker:19.03 docker-19.03
 docker:latest docker-latest
-docker:stable docker
+docker:latest docker
 python:alpine python-alpine
 ruby:alpine ruby-alpine


### PR DESCRIPTION
docker:stable wasn't updated in 10 months https://hub.docker.com/layers/docker/library/docker/stable/images/sha256-ce46ea18798c578f8923e0ced4c9996c30363fc35edd1b1c40e5e542407818ac?context=explore

We are forced to switch to docker:latest for the snyk/snyk:docker tag. This will result in a duplicate tag with snyk/snyk:docker-latest