### PR TITLE
fix: allow to use a command including space

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -89,4 +89,4 @@ if [ "$INPUT_COMMAND" = "test" -a "$INPUT_SARIF" = "true" ]; then
     fi
 fi
 
-exec $@ $JSON_OUTPUT $SARIF_OUTPUT
+sh -c "$* $JSON_OUTPUT $SARIF_OUTPUT"


### PR DESCRIPTION
This change allows GitHub actions to execute `{{ $input.args }}` and allows other CI pipelines to execute commands as well.

 In the documentation [dockerfile-support-for-github-actions](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#entrypoint) the entrypoint example shows this solution. I checked with GitHub action as well as with my CI provider buildkite. I can't speak for other providers but this change worked for me. Maybe you can test it again.