### PR TITLE
feat: use linuxstatic binaries by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 ARG IMAGE
 ARG CLI_VERSION=latest
+ARG EXPERIMENTAL_BASE_URL=https://downloads.snyk.io/experimental
 
 FROM ${IMAGE} AS parent
 
 ARG TAG
+ARG EXPERIMENTAL_BASE_URL
 
 ENV MAVEN_CONFIG="" \
     SNYK_INTEGRATION_NAME="DOCKER_SNYK" \
     SNYK_INTEGRATION_VERSION=${TAG} \
     SNYK_CFG_DISABLESUGGESTIONS=true \
-    SNYK_CLI_VERSION=${CLI_VERSION}
+    SNYK_CLI_VERSION=${CLI_VERSION} \
+    SNYK_CLI_DOWNLOAD_URL=${EXPERIMENTAL_BASE_URL}
 WORKDIR /app
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
@@ -19,21 +22,27 @@ FROM ubuntu AS snyk
 ARG CLI_VERSION
 ENV SNYK_CLI_VERSION=$CLI_VERSION
 RUN echo "SNYK_CLI_VERSION=${SNYK_CLI_VERSION}"
+ARG EXPERIMENTAL_BASE_URL
+ENV SNYK_CLI_DOWNLOAD_URL=$EXPERIMENTAL_BASE_URL
+RUN echo "SNYK_CLI_DOWNLOAD_URL=${SNYK_CLI_DOWNLOAD_URL}"
 
 RUN apt-get update && apt-get install -y curl python3 python3-requests
 RUN curl --compressed --output /usr/local/bin/install-snyk.py https://raw.githubusercontent.com/snyk/cli/main/scripts/install-snyk.py
 RUN chmod +x /usr/local/bin/install-snyk.py
-RUN install-snyk.py $SNYK_CLI_VERSION
+RUN install-snyk.py $SNYK_CLI_VERSION --base_url=$SNYK_CLI_DOWNLOAD_URL
 
 FROM alpine AS snyk-alpine
 ARG CLI_VERSION
 ENV SNYK_CLI_VERSION=$CLI_VERSION
 RUN echo "SNYK_CLI_VERSION=${SNYK_CLI_VERSION}"
+ARG EXPERIMENTAL_BASE_URL
+ENV SNYK_CLI_DOWNLOAD_URL=$EXPERIMENTAL_BASE_URL
+RUN echo "SNYK_CLI_DOWNLOAD_URL=${SNYK_CLI_DOWNLOAD_URL}"
 
 RUN apk update && apk add --no-cache git curl python3 py3-requests
 RUN curl --compressed --output /usr/local/bin/install-snyk.py https://raw.githubusercontent.com/snyk/cli/main/scripts/install-snyk.py
 RUN chmod +x /usr/local/bin/install-snyk.py
-RUN install-snyk.py $SNYK_CLI_VERSION
+RUN install-snyk.py $SNYK_CLI_VERSION --base_url=$SNYK_CLI_DOWNLOAD_URL
 
 FROM parent AS alpine
 RUN apk update && apk upgrade --no-cache


### PR DESCRIPTION
This PR changes the linux Snyk CLI binaries used for Linux based images from statically linked `snyk-linux` binaries to dynamically linked `snyk-linux` binaries