### PR TITLE
fix: do not use linuxstatic binaries for alpine based images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,11 @@ FROM alpine AS snyk-alpine
 ARG CLI_VERSION
 ENV SNYK_CLI_VERSION=$CLI_VERSION
 RUN echo "SNYK_CLI_VERSION=${SNYK_CLI_VERSION}"
-ARG EXPERIMENTAL_BASE_URL
-ENV SNYK_CLI_DOWNLOAD_URL=$EXPERIMENTAL_BASE_URL
-RUN echo "SNYK_CLI_DOWNLOAD_URL=${SNYK_CLI_DOWNLOAD_URL}"
 
 RUN apk update && apk add --no-cache git curl python3 py3-requests
 RUN curl --compressed --output /usr/local/bin/install-snyk.py https://raw.githubusercontent.com/snyk/cli/main/scripts/install-snyk.py
 RUN chmod +x /usr/local/bin/install-snyk.py
-RUN install-snyk.py $SNYK_CLI_VERSION --base_url=$SNYK_CLI_DOWNLOAD_URL
+RUN install-snyk.py $SNYK_CLI_VERSION
 
 FROM parent AS alpine
 RUN apk update && apk upgrade --no-cache


### PR DESCRIPTION
Currently the script's fallback mechanism ensures the correct binary is downloaded, but this fix just makes it download the via the correct URL without using the fallback.

Before:
<img width="817" height="427" alt="Screenshot 2026-05-12 at 10 21 31" src="https://github.com/user-attachments/assets/58bf75b8-eade-4e21-84ce-33949dd6f0a5" />


After:
<img width="753" height="192" alt="Screenshot 2026-05-12 at 10 22 12" src="https://github.com/user-attachments/assets/5efe6721-8b48-4f43-a936-a021df07893a" />
